### PR TITLE
Incorrect group id.

### DIFF
--- a/content/pom.xml
+++ b/content/pom.xml
@@ -110,7 +110,7 @@
                     <!-- embedded dependencies in the content package -->
                     <embeddeds>
                         <embedded>
-                            <groupId>com.adobe.communities</groupId>
+                            <groupId>com.adobe.aem.communities</groupId>
                             <artifactId>communities-ugc-migration</artifactId>
                             <target>/apps/migration/install</target>
                         </embedded>
@@ -221,7 +221,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.adobe.communities</groupId>
+            <groupId>com.adobe.aem.communities</groupId>
             <artifactId>communities-ugc-migration</artifactId>
             <version>1.0.0-SNAPSHOT</version>
         </dependency>


### PR DESCRIPTION
This just adds the aem prefix on the embedded dependency.